### PR TITLE
Passing options to Pygments not working as described on the readme

### DIFF
--- a/lib/middleman-syntax/extension.rb
+++ b/lib/middleman-syntax/extension.rb
@@ -51,13 +51,15 @@ module Middleman
           @_out_buf = _buf_was
         end
 
-        concat_content Pygments.highlight(code, :lexer => language, :options => ::Middleman::Syntax.options)
+        options = ::Middleman::Syntax.options.merge :lexer => language
+        concat_content Pygments.highlight(code, :options => options)
       end
     end
 
     module MarkdownCodeRenderer
       def block_code(code, language)
-        Pygments.highlight(code, :lexer => language, :options => ::Middleman::Syntax.options)
+        options = ::Middleman::Syntax.options.merge :lexer => language
+        Pygments.highlight(code, :options => options)
       end
     end
   end


### PR DESCRIPTION
Merges :lexer into the ::Middleman::Syntax.options hash.

Loved the idea, and tried the examples on the readme, but the line numbers just weren't coming up. Dug into Pygments.rb and I have a small tweak that fixes it for me.
