### PR TITLE
Evade errors when language = ''

### DIFF
--- a/lib/middleman-syntax/extension.rb
+++ b/lib/middleman-syntax/extension.rb
@@ -58,7 +58,8 @@ module Middleman
 
     module MarkdownCodeRenderer
       def block_code(code, language)
-        options = ::Middleman::Syntax.options.merge :lexer => language
+        options = ::Middleman::Syntax.options
+        options.merge :lexer => language if language
         Pygments.highlight(code, :options => options)
       end
     end


### PR DESCRIPTION
Happens sometimes with old/bad markdown code. It may had something to do with line endings but I couldn't figure it out. 
