### PR TITLE
Add support for Kramdown as Markdown engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+master
+------
+
+* Support Kramdown as Markdown engine in addition to Redcarpet.
+
+1.1.1
+-----
+
+* Properly merge language attribute for Markdown. #14
+
 1.1.0
 -----
 

--- a/README.md
+++ b/README.md
@@ -44,14 +44,18 @@ That'll produce syntax-highlighted HTML wrapped in a `<pre>` tag, wrapped in `<d
 
 **Note** that on a default (i.e. unstyled) Middleman project, it will appear as if `middleman-syntax` isn't working, since none of the Pygments styles have any CSS applied! Open the browser Developer Tools to verify the code is being syntax highlighted.
 
-The extension also makes code blocks in Markdown highlight code. Make sure you're using RedCarpet as your Markdown engine (in `config.rb`):
+The extension also makes code blocks in Markdown highlight code. Make sure you're using RedCarpet or Kramdown as your Markdown engine (in `config.rb`):
 
 ```ruby
 set :markdown_engine, :redcarpet
 set :markdown, :fenced_code_blocks => true, :smartypants => true
+
+# OR
+
+set :markdown_engine, :kramdown
 ```
 
-Now your Markdown will work just like it does [on GitHub](http://github.github.com/github-flavored-markdown/) - you can write something like this:
+Now your Markdown will work just like it does [on GitHub](http://github.github.com/github-flavored-markdown/) - you can write something like this with Redcarpet:
 
 <pre>
 ```ruby
@@ -59,6 +63,16 @@ def my_cool_method(message)
   puts message
 end
 ```
+</pre>
+
+or with Kramdown:
+
+<pre>
+~~~ ruby
+def my_cool_method(message)
+  puts message
+end
+~~~
 </pre>
 
 # Bug Reports

--- a/lib/middleman-syntax/extension.rb
+++ b/lib/middleman-syntax/extension.rb
@@ -14,8 +14,24 @@ module Middleman
 
         app.send :include, Helper
 
-        require 'middleman-core/renderers/redcarpet'
-        Middleman::Renderers::MiddlemanRedcarpetHTML.send :include, MarkdownCodeRenderer
+        begin
+          require 'redcarpet'
+          require 'middleman-core/renderers/redcarpet'
+          Middleman::Renderers::MiddlemanRedcarpetHTML.send :include, MarkdownCodeRenderer
+        rescue LoadError
+        end
+
+        begin
+          require 'kramdown'
+          Kramdown::Converter::Html.class_eval do
+            def convert_codeblock(el, indent)
+              attr = el.attr.dup
+              lang = (extract_code_language!(attr) || :plain).to_sym
+              Pygments.highlight(el.value, :lexer => lang).chomp
+            end
+          end
+        rescue LoadError
+        end
       end
       alias :included :registered
     end


### PR DESCRIPTION
I've been having all sorts of trouble with Redcarpet lately, so I thought I'd take a shot at getting a couple of Middleman's coolest Redcarpet-specific features working with Kramdown.  Here's a patch for Pygments syntax highlighting.

(Yes, I know that Kramdown ships with support for Coderay, but it lacks parsers for many of the languages I need on my site, and this patch makes the Redcarpet-to-Kramdown transition one that doesn't lose any features or make me have to rework my stylesheets.)
