### PR TITLE
Readme Correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You can also let Rouge generate some CSS for you by creating a new stylesheet wi
 <%= Rouge::Themes::ThankfulEyes.render(:scope => '.highlight') %>
 ```
 
-Rouge has `ThankfulEyes`, `Colorful`, `GitHub`, `Base16`, `Base16::Solarized` (like Octopress), and `Base16::Monokai` themes.
+Rouge has `ThankfulEyes`, `Colorful`, `Github`, `Base16`, `Base16::Solarized` (like Octopress), and `Base16::Monokai` themes.
 
 ## Markdown
 


### PR DESCRIPTION
Minor change. Changed `GitHub` to `Github` which is the correct class name in Rouge::Themes. 
