### PR TITLE
Force encoding to UTF8 before passing content to highlighter

### DIFF
--- a/lib/middleman-syntax/extension.rb
+++ b/lib/middleman-syntax/extension.rb
@@ -74,7 +74,7 @@ module Middleman
           # Reset stored buffer
           @_out_buf = _buf_was
         end
-
+        content = content.encode(Encoding::UTF_8)
         concat_content Middleman::Syntax::Highlighter.highlight(content, language)
       end
     end


### PR DESCRIPTION
Rouge expects content to be a valid UTF8 string.  If the string does not contain UTF-8 Characters, it is casted to ASCII-8BIT, Triggerring an error:

To reproduce:
**index.slim**

```
- code('html') do
  == "BOB".force_encoding(Encoding::UTF_8)
```

=>

```
Bad encoding: ASCII-8BIT,BINARY. Please convert your string to UTF-8.
```

**index.slim**

```
- code('html') do
  == "BOBé".force_encoding(Encoding::UTF_8)
```

=> Works.

We make sure "content" passed to highlighter a valid UTF8 string.
