### PR TITLE
Clean up css_class option

### DIFF
--- a/lib/middleman-syntax/extension.rb
+++ b/lib/middleman-syntax/extension.rb
@@ -78,7 +78,7 @@ module Middleman
         lexer = Rouge::Lexer.find_fancy(language, code) || Rouge::Lexers::PlainText
 
         highlighter_options = options.to_h.merge(opts)
-        highlighter_options[:css_class] = [ highlighter_options[:css_class], lexer.tag ].join(' ')
+        highlighter_options[:css_class] = [ highlighter_options[:css_class], lexer.tag ].reject(&:blank?).join(' ')
         lexer_options = highlighter_options.delete(:lexer_options)
 
         formatter = Rouge::Formatters::HTML.new(highlighter_options)


### PR DESCRIPTION
`css_class: false` added 'false' to the output CSS class instead of behaving like `nil` or `''`, which both also added a leading space.
