### PR TITLE
Update Rouge and fix CSS class bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
-2.0.0 (master)
+2.1.0 (master)
+-----
+
+* Breaking: Code blocks are now also wrapped in a \<code> tag, which is consistent with Redcarpet and other markdown processors ([see the HTML5 spec](http://www.w3.org/TR/2011/WD-html5-author-20110809/the-code-element.html)).
+* Strings can now be passed to `:inline_theme` for convenience.
+* Added new `monokai.sublime` theme, designed to match Sublime Text's default theme.
+* Added `:start_line` option to configure the starting index used for line numbers.
+* Fixed bugs with `:css_class` where `false` was coerced into a string and blank spaces were sometimes added
+* Prevented adding an empty class attribute if the `:css_class` option is empty/nil/false
+* If the `:css_class` ends with a dash it will now be concatenated to the language tag. This means you can use the `language-#{lang}` prefix suggested in [the HTML5 spec](http://www.w3.org/TR/2011/WD-html5-author-20110809/the-code-element.html).
+
+2.0.0
 -----
 
 * Update to a new-style Middleman extension, dropping compatibility with Middleman versions older than 3.2.x.

--- a/features/haml_filter.feature
+++ b/features/haml_filter.feature
@@ -10,4 +10,4 @@ Feature: Haml :code filter.
     Given the Server is running at "test-app"
     When I go to "/code_haml_filter.html"
     Then I should see '<span class="k">def</span>'
-    Then I should see '<pre class="highlight plaintext">This is some code'
+    Then I should see '<pre><code class="highlight plaintext">This is some code'

--- a/features/helper.feature
+++ b/features/helper.feature
@@ -4,16 +4,16 @@ Feature: Syntax highlighting with the "code" helper method
     Given the Server is running at "test-app"
     When I go to "/code_html.html"
     Then I should see '<span class="k">def</span>'
-    Then I should see '<pre class="highlight plaintext">This is some code'
+    Then I should see '<pre><code class="highlight plaintext">This is some code'
 
   Scenario: Works from Haml
     Given the Server is running at "test-app"
     When I go to "/code_haml.html"
     Then I should see '<span class="k">def</span>'
-    Then I should see '<pre class="highlight plaintext">This is some code'
+    Then I should see '<pre><code class="highlight plaintext">This is some code'
 
   Scenario: Works from Slim
     Given the Server is running at "test-app"
     When I go to "/code_slim.html"
     Then I should see '<span class="k">def</span>'
-    Then I should see '<pre class="highlight plaintext">This is some code'
+    Then I should see '<pre><code class="highlight plaintext">This is some code'

--- a/features/markdown.feature
+++ b/features/markdown.feature
@@ -10,7 +10,7 @@ Feature: Code blocks in markdown get highlighted
     Given the Server is running at "test-app"
     When I go to "/code.html"
     Then I should see '<span class="k">def</span>'
-    Then I should see '<pre class="highlight plaintext">This is some code'
+    Then I should see '<pre><code class="highlight plaintext">This is some code'
 
   @nojava
   Scenario: Works with RedCarpet
@@ -24,5 +24,5 @@ Feature: Code blocks in markdown get highlighted
     Given the Server is running at "test-app"
     When I go to "/code.html"
     Then I should see '<span class="k">def</span>'
-    Then I should see '<pre class="highlight plaintext">This is some code'
-    
+    Then I should see '<pre><code class="highlight plaintext">This is some code'
+

--- a/lib/middleman-syntax/version.rb
+++ b/lib/middleman-syntax/version.rb
@@ -1,5 +1,5 @@
 module Middleman
   module Syntax
-    VERSION = "2.0.0"
+    VERSION = "2.1.0"
   end
 end

--- a/middleman-syntax.gemspec
+++ b/middleman-syntax.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files -z -- {fixtures,features}/*`.split("\0")
   s.require_paths = ["lib"]
   s.add_runtime_dependency("middleman-core", ["~> 3.2"])
-  s.add_runtime_dependency("rouge", ["~> 1.0"])
+  s.add_runtime_dependency("rouge", ["~> 1.4"])
 end


### PR DESCRIPTION
Incorporates #41
[See the changelog](https://github.com/Arcovion/middleman-syntax/blob/6854f1ca8c4934724cb59b69f8d7f752f23b5b33/CHANGELOG.md) for more details and explanations.
Note the failing specs are due to #38 
I also changed the version number here which I probably shouldn't have; just wanted to write the changelog update myself :P

This patch also automatically joins the CSS class and language together if the chosen CSS class ends with a dash, allowing further compatibility with [the HTML5 spec](http://www.w3.org/TR/2011/WD-html5-author-20110809/the-code-element.html). Could use a `lang_prefix: 'string'` option instead, or just allow any prefix with <code>```prefix-lang</code> and give the suffix to the lexer.
What do you think is the best way to handle the prefix?
