### PR TITLE
Move as many dependencies as possible to the gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,18 +8,9 @@ gemspec
 gem "rake",     "~> 10.1.0", :require => false
 gem "yard",     "~> 0.8.0", :require => false
 
-# Test tools
-gem "cucumber", "~> 1.3.1"
-gem "fivemat"
-gem "aruba",    "~> 0.5.1"
-gem "haml"
-
 platforms :ruby do
   gem "redcarpet"
 end
-
-gem "kramdown"
-gem "slim"
 
 # Code Quality
 gem "cane", :platforms => [:mri_19, :mri_20], :require => false

--- a/Rakefile
+++ b/Rakefile
@@ -26,6 +26,8 @@ rescue LoadError
   # warn "cane not available, quality task not provided."
 end
 
+task :default => :test
+
 desc "Build HTML documentation"
 task :doc do
   sh 'bundle exec yard'

--- a/middleman-syntax.gemspec
+++ b/middleman-syntax.gemspec
@@ -17,4 +17,10 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.add_runtime_dependency("middleman-core", ["~> 3.2"])
   s.add_runtime_dependency("rouge", ["~> 1.0"])
+  s.add_development_dependency("aruba", "~> 0.5.1")
+  s.add_development_dependency("cucumber", "~> 1.3.1")
+  s.add_development_dependency("fivemat")
+  s.add_development_dependency("haml")
+  s.add_development_dependency("kramdown")
+  s.add_development_dependency("slim")
 end


### PR DESCRIPTION
Ideally, all dependencies would be in the gemspec, but features like `platform` and `require: false` are only available in the Gemfile.

Also, `rake` runs `rake test`.