### PR TITLE
Include Rouge formatter options in code helper instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ end
 
 For more on Haml syntax, see the "Haml" section below.
 
-The `code` helper supports [Rouge](https://github.com/jayferd/rouge) instance formatter options such as:
+The `code` helper supports [Rouge](https://github.com/jayferd/rouge) instance formatter options. These override the defaults set in your `config.rb`. Example options include:
 
 * `line_numbers`
 * `start_line`
@@ -68,12 +68,14 @@ The `code` helper supports [Rouge](https://github.com/jayferd/rouge) instance fo
 To use these formatter options per code block, include them in a hash as the second argument. e.g.
 
 ```erb
-<% code("ruby", {:line_numbers => true, :start_line => 7}) do %>
+<% code("ruby", :line_numbers => true, :start_line => 7) do %>
 def my_cool_method(message)
   puts message
 end
 <% end %>
 ```
+
+
 
 ## CSS
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ def my_cool_method(message)
 end
 <% end %>
 ```
-
-In Haml, use `=`, not `-`:
+*Note:* In Haml, use `=`, not `-`:
 
 ```haml
 = code('ruby') do
@@ -58,6 +57,23 @@ In Haml, use `=`, not `-`:
 ```
 
 For more on Haml syntax, see the "Haml" section below.
+
+The `code` helper supports [Rouge](https://github.com/jayferd/rouge) formatter options such as:
+
+* `line_numbers`
+* `start_line`
+* `css_class`
+* `wrap`
+
+To use these formatter options, include them in a hash as the second argument. e.g.
+
+```erb
+<% code("html", {:line_numbers => true, :start_line => 7}) do %>
+def my_cool_method(message)
+  puts message
+end
+<% end %>
+```
 
 ## CSS
 

--- a/README.md
+++ b/README.md
@@ -58,17 +58,17 @@ end
 
 For more on Haml syntax, see the "Haml" section below.
 
-The `code` helper supports [Rouge](https://github.com/jayferd/rouge) formatter options such as:
+The `code` helper supports [Rouge](https://github.com/jayferd/rouge) instance formatter options such as:
 
 * `line_numbers`
 * `start_line`
 * `css_class`
 * `wrap`
 
-To use these formatter options, include them in a hash as the second argument. e.g.
+To use these formatter options per code block, include them in a hash as the second argument. e.g.
 
 ```erb
-<% code("html", {:line_numbers => true, :start_line => 7}) do %>
+<% code("ruby", {:line_numbers => true, :start_line => 7}) do %>
 def my_cool_method(message)
   puts message
 end

--- a/features/helper.feature
+++ b/features/helper.feature
@@ -17,3 +17,18 @@ Feature: Syntax highlighting with the "code" helper method
     When I go to "/code_slim.html"
     Then I should see '<span class="k">def</span>'
     Then I should see '<pre class="highlight plaintext"><code>This is some code'
+
+  Scenario: options start_line works from erb
+    Given the Server is running at "test-app"
+    When I go to "/code_html.html"
+    Then I should see '<pre class="lineno">7'
+
+  Scenario: options start_line works from Haml
+    Given the Server is running at "test-app"
+    When I go to "/code_haml.html"
+    Then I should see '<pre class="lineno">7'
+
+  Scenario: options start_line works from Slim
+    Given the Server is running at "test-app"
+    When I go to "/code_slim.html"
+    Then I should see '<pre class="lineno">7'

--- a/fixtures/test-app/source/code_haml.html.haml
+++ b/fixtures/test-app/source/code_haml.html.haml
@@ -10,3 +10,11 @@
 
 = code do
   This is some code
+
+%h1 Options
+
+= code('ruby', {:line_numbers => true, :start_line => 7}) do
+  :preserve
+    def foo(bar)
+      puts "baz"
+    end

--- a/fixtures/test-app/source/code_html.html.erb
+++ b/fixtures/test-app/source/code_html.html.erb
@@ -12,3 +12,11 @@ end
 <% code do %>
 This is some code
 <% end %>
+
+<h1>Options</h1>
+
+<% code('ruby', {:line_numbers => true, :start_line => 7}) do %>
+def foo(bar)
+  puts "baz"
+end
+<% end %>

--- a/fixtures/test-app/source/code_slim.html.slim
+++ b/fixtures/test-app/source/code_slim.html.slim
@@ -11,3 +11,11 @@ h1 Whatever
 = code
   |
     This is some code
+
+h1 Options
+
+= code('ruby', {:line_numbers => true, :start_line => 7}) do
+  |
+    def foo(bar)
+      puts "baz"
+    end

--- a/lib/middleman-syntax/extension.rb
+++ b/lib/middleman-syntax/extension.rb
@@ -61,7 +61,7 @@ module Middleman
           end
           content = content.encode(Encoding::UTF_8)
 
-          concat_content Middleman::Syntax::Highlighter.highlight(content, language).html_safe
+          concat_content Middleman::Syntax::Highlighter.highlight(content, language, options).html_safe
         end
       end
     end

--- a/lib/middleman-syntax/extension.rb
+++ b/lib/middleman-syntax/extension.rb
@@ -8,6 +8,7 @@ module Middleman
     class SyntaxExtension < Extension
       option :css_class, 'highlight', 'Class name applied to the syntax-highlighted output.'
       option :line_numbers, false, 'Generate line numbers.'
+      option :start_line, 1, 'Start the line numbering (if enabled) at the desired integer'
       option :inline_theme, nil, 'A Rouge::CSSTheme that will be used to highlight the output with inline styles instead of using CSS classes.'
       option :wrap, true, 'Wrap the highlighted content in a container (<pre> or <div>, depending on whether :line_numbers is on).'
       option :lexer_options, {}, 'Options for the Rouge lexers.'
@@ -33,7 +34,7 @@ module Middleman
       helpers do
         # Output highlighted code. Use like:
         #
-        #    <% code('ruby') do %>
+        #    <% code('ruby', :line_numbers => true, :start_line => 7) do %>
         #      my code
         #    <% end %>
         #


### PR DESCRIPTION
Hi gang,
This pull request adds the `options` hash to the `code` helper, so that the template author can override or set options on the code blocks they're working on.
I've included some feature tests that use `line_numbers` and `start_line` options, and updated the README.
-nd