### PR TITLE
Add the explanation to prevent stylesheet from being recognized as a …

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ You can also let Rouge generate some CSS for you by creating a new stylesheet wi
 <%= Rouge::Themes::ThankfulEyes.render(:scope => '.highlight') %>
 ```
 
+To prevent the stylesheet from being recognized as a html page source when running `middleman buid`, add an underscore at the beginning of the filename or add `ignore "/this/file/path.css.erb"` to config.rb.
+
 Rouge has `ThankfulEyes`, `Colorful`, `Github`, `Base16`, `Base16::Solarized` (like Octopress), `Base16::Monokai`, and `Monokai` themes.
 
 ## Markdown

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ You can also let Rouge generate some CSS for you by creating a new stylesheet wi
 <%= Rouge::Themes::ThankfulEyes.render(:scope => '.highlight') %>
 ```
 
-To prevent the stylesheet from being recognized as a html page source when running `middleman buid`, add an underscore at the beginning of the filename or add `ignore "/this/file/path.css.erb"` to config.rb.
+To prevent the stylesheet from being recognized as a html page source when running `middleman build`, add an underscore at the beginning of the filename or add `ignore "/this/file/path.css.erb"` to config.rb.
 
 Rouge has `ThankfulEyes`, `Colorful`, `Github`, `Base16`, `Base16::Solarized` (like Octopress), `Base16::Monokai`, and `Monokai` themes.
 


### PR DESCRIPTION
…html source.

I think because the most of the new comer should see the following error when running `middleman build`, the explanation should be helpful.

```
       error  build/stylesheets/highlighting/index.html
Not found
```