### PR TITLE
Allow middleman-core v4 dependency

### DIFF
--- a/middleman-syntax.gemspec
+++ b/middleman-syntax.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -z`.split("\0")
   s.test_files = `git ls-files -z -- {fixtures,features}/*`.split("\0")
   s.require_paths = ["lib"]
-  s.add_runtime_dependency("middleman-core", ["~> 3.2"])
+  s.add_runtime_dependency("middleman-core", [">= 3.2"])
   s.add_runtime_dependency("rouge", ["~> 1.0"])
   s.add_development_dependency("aruba", "~> 0.5.1")
   s.add_development_dependency("cucumber", "~> 1.3.1")


### PR DESCRIPTION
Solve this: https://github.com/middleman/middleman-syntax/issues/57