### PR TITLE
Disable the line numbers on a specific code block when using Markdown and Redcarpet

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,18 @@ end
 ```
 </pre>
 
+You can also disable the line numbers on a specific code block. However, this is Middleman-syntax specific feature, which only works when using Redcarpert.
+
+Disabling the line numbers on a code block:
+
+<pre>
+```ruby?line_numbers=false
+def my_cool_method(message)
+  puts message
+end
+```
+</pre>
+
 or with Kramdown:
 
 <pre>

--- a/features/markdown_line_numbers_disabled.feature
+++ b/features/markdown_line_numbers_disabled.feature
@@ -1,0 +1,25 @@
+Feature: Code blocks with line numbers in markdown
+  Scenario: Disabled line numbers with Kramdown
+    Given a fixture app "test-app"
+    And a file named "config.rb" with:
+      """
+      set :markdown_engine, :kramdown
+      set :markdown, :fenced_code_blocks => true
+      activate :syntax, :line_numbers => true
+      """
+    Given the Server is running at "test-app"
+    When I go to "/code_with_disabled_line_numbers.html"
+    Then I should not see line numbers markup
+
+  @nojava
+  Scenario: Disabled line numbers with Redcarpet
+    Given a fixture app "test-app"
+    And a file named "config.rb" with:
+      """
+      set :markdown_engine, :redcarpet
+      set :markdown, :fenced_code_blocks => true
+      activate :syntax, :line_numbers => true
+      """
+    Given the Server is running at "test-app"
+    When I go to "/code_with_disabled_line_numbers.html"
+    Then I should not see line numbers markup

--- a/features/markdown_line_numbers_disabled.feature
+++ b/features/markdown_line_numbers_disabled.feature
@@ -1,16 +1,4 @@
 Feature: Code blocks with line numbers in markdown
-  Scenario: Disabled line numbers with Kramdown
-    Given a fixture app "test-app"
-    And a file named "config.rb" with:
-      """
-      set :markdown_engine, :kramdown
-      set :markdown, :fenced_code_blocks => true
-      activate :syntax, :line_numbers => true
-      """
-    Given the Server is running at "test-app"
-    When I go to "/code_with_disabled_line_numbers.html"
-    Then I should not see line numbers markup
-
   @nojava
   Scenario: Disabled line numbers with Redcarpet
     Given a fixture app "test-app"

--- a/features/markdown_line_numbers_enabled.feature
+++ b/features/markdown_line_numbers_enabled.feature
@@ -1,16 +1,4 @@
 Feature: Code blocks with line numbers in markdown
-  Scenario: Line numbers enabled with Kramdown
-    Given a fixture app "test-app"
-    And a file named "config.rb" with:
-      """
-      set :markdown_engine, :kramdown
-      set :markdown, :fenced_code_blocks => true
-      activate :syntax, :line_numbers => true
-      """
-    Given the Server is running at "test-app"
-    When I go to "/code_with_enabled_line_numbers.html"
-    Then I should see '<pre class="lineno">'
-
   @nojava
   Scenario: Line numbers enabled with Redcarpet
     Given a fixture app "test-app"

--- a/features/markdown_line_numbers_enabled.feature
+++ b/features/markdown_line_numbers_enabled.feature
@@ -1,0 +1,25 @@
+Feature: Code blocks with line numbers in markdown
+  Scenario: Line numbers enabled with Kramdown
+    Given a fixture app "test-app"
+    And a file named "config.rb" with:
+      """
+      set :markdown_engine, :kramdown
+      set :markdown, :fenced_code_blocks => true
+      activate :syntax, :line_numbers => true
+      """
+    Given the Server is running at "test-app"
+    When I go to "/code_with_enabled_line_numbers.html"
+    Then I should see '<pre class="lineno">'
+
+  @nojava
+  Scenario: Line numbers enabled with Redcarpet
+    Given a fixture app "test-app"
+    And a file named "config.rb" with:
+      """
+      set :markdown_engine, :redcarpet
+      set :markdown, :fenced_code_blocks => true
+      activate :syntax, :line_numbers => true
+      """
+    Given the Server is running at "test-app"
+    When I go to "/code_with_enabled_line_numbers.html"
+    Then I should see '<pre class="lineno">'

--- a/features/support/step_definitions.rb
+++ b/features/support/step_definitions.rb
@@ -1,0 +1,4 @@
+# step definition for testing line number markup
+Then(/^I should not see line numbers markup$/) do
+  expect(page).not_to have_selector("pre.lineno")
+end

--- a/fixtures/test-app/source/code_with_disabled_line_numbers.html.markdown
+++ b/fixtures/test-app/source/code_with_disabled_line_numbers.html.markdown
@@ -1,0 +1,7 @@
+# Ruby with no line numbers
+
+~~~ruby?line_numbers=false
+def foo(bar)
+  puts "baz"
+end
+~~~

--- a/fixtures/test-app/source/code_with_enabled_line_numbers.html.markdown
+++ b/fixtures/test-app/source/code_with_enabled_line_numbers.html.markdown
@@ -1,0 +1,25 @@
+# Ruby with line numbers
+
+~~~ruby?line_numbers=
+def foo(bar)
+  puts "baz"
+end
+~~~
+
+~~~ruby?line_numbers
+def foo(bar)
+  puts "baz"
+end
+~~~
+
+~~~ruby?line_numbers=flase
+def foo(bar)
+  puts "baz"
+end
+~~~
+
+# Whatever
+
+~~~
+This is some code
+~~~

--- a/lib/middleman-syntax/extension.rb
+++ b/lib/middleman-syntax/extension.rb
@@ -2,6 +2,7 @@ require 'rouge'
 require 'middleman-syntax/highlighter'
 require 'middleman-syntax/redcarpet_code_renderer'
 require 'middleman-syntax/haml_monkey_patch'
+require 'middleman-syntax/language_parameter_parser.rb'
 
 module Middleman
   module Syntax
@@ -15,7 +16,6 @@ module Middleman
 
       def after_configuration
         Middleman::Syntax::Highlighter.options = options
-
         if app.config[:markdown_engine] == :redcarpet
           require 'middleman-core/renderers/redcarpet'
           Middleman::Renderers::MiddlemanRedcarpetHTML.send :include, RedcarpetCodeRenderer

--- a/lib/middleman-syntax/highlighter.rb
+++ b/lib/middleman-syntax/highlighter.rb
@@ -5,6 +5,15 @@ module Middleman
 
       # A helper module for highlighting code
       def self.highlight(code, language=nil, opts={})
+        puts "============================================="
+        puts "Highlighter.highlight()"
+        puts "  opts: #{opts}"
+        puts "  language: #{language}"
+        puts "  options: #{options}"
+        puts "============================================="
+        if language == "plain"
+          options[:line_numbers] = false
+        end
         lexer = Rouge::Lexer.find_fancy(language, code) || Rouge::Lexers::PlainText
 
         highlighter_options = options.to_h.merge(opts)

--- a/lib/middleman-syntax/highlighter.rb
+++ b/lib/middleman-syntax/highlighter.rb
@@ -5,13 +5,7 @@ module Middleman
 
       # A helper module for highlighting code
       def self.highlight(code, language=nil, opts={})
-        puts "============================================="
-        puts "Highlighter.highlight()"
-        puts "  opts: #{opts}"
-        puts "  language: #{language}"
-        puts "  options: #{options}"
-        puts "============================================="
-        if language == "plain"
+        if "plain" == language
           options[:line_numbers] = false
         end
         lexer = Rouge::Lexer.find_fancy(language, code) || Rouge::Lexers::PlainText

--- a/lib/middleman-syntax/highlighter.rb
+++ b/lib/middleman-syntax/highlighter.rb
@@ -5,9 +5,6 @@ module Middleman
 
       # A helper module for highlighting code
       def self.highlight(code, language=nil, opts={})
-        if "plain" == language
-          options[:line_numbers] = false
-        end
         lexer = Rouge::Lexer.find_fancy(language, code) || Rouge::Lexers::PlainText
 
         highlighter_options = options.to_h.merge(opts)

--- a/lib/middleman-syntax/language_parameter_parser.rb
+++ b/lib/middleman-syntax/language_parameter_parser.rb
@@ -1,0 +1,17 @@
+module Middleman
+  module Syntax
+    module LanguageParameterParser
+      def self.parse_parameter_from_language(language = "")
+        language, params = language.to_s.split("?", 2)
+        if params and params.to_s.include? "="
+          attribute, value = params.to_s.split("=")
+          # if there are more arguments, refactor this
+          if attribute == "line_numbers" and value == "false"
+            return { line_numbers: false }
+          end
+        end
+        {}
+      end
+    end
+  end
+end

--- a/lib/middleman-syntax/redcarpet_code_renderer.rb
+++ b/lib/middleman-syntax/redcarpet_code_renderer.rb
@@ -1,10 +1,13 @@
+require 'middleman-syntax/language_parameter_parser.rb'
+
 module Middleman
   module Syntax
     # A mixin for the Redcarpet Markdown renderer that will highlight
     # code.
     module RedcarpetCodeRenderer
       def block_code(code, language)
-        Middleman::Syntax::Highlighter.highlight(code, language)
+        opts = Middleman::Syntax::LanguageParameterParser.parse_parameter_from_language(language)
+        Middleman::Syntax::Highlighter.highlight(code, language, opts)
       end
     end
   end


### PR DESCRIPTION
This is a pull request for a issue which was discussed earlier on #62.

Adds parameter handler for markdown and redcarpet renderer, currently only support ```line_numbers=false``` option.

Example:

    ```ruby?line_numbers=false
    def my_cool_method(message)
      puts message
    end
    ```


