### PR TITLE
Upgrade to Rouge 2.0

### DIFF
--- a/lib/middleman-syntax/formatters.rb
+++ b/lib/middleman-syntax/formatters.rb
@@ -1,0 +1,27 @@
+module Middleman
+  module Syntax
+    module Formatters
+      class HTML < Rouge::Formatter
+        tag 'html'
+
+        def initialize(opts={})
+          @formatter = if opts[:inline_theme]
+                         Rouge::Formatters::HTMLInline.new(opts[:inline_theme])
+                       else
+                         Rouge::Formatters::HTML.new
+                       end
+
+          @formatter = Rouge::Formatters::HTMLTable.new(@formatter, opts) if opts[:line_numbers]
+
+          if opts.fetch(:wrap, true)
+            @formatter = Rouge::Formatters::HTMLPygments.new(@formatter, opts.fetch(:css_class, 'codehilite'))
+          end
+        end
+
+        def stream(tokens, &block)
+          @formatter.stream(tokens, &block)
+        end
+      end
+    end
+  end
+end

--- a/lib/middleman-syntax/highlighter.rb
+++ b/lib/middleman-syntax/highlighter.rb
@@ -1,3 +1,5 @@
+require 'middleman-syntax/formatters'
+
 module Middleman
   module Syntax
     module Highlighter
@@ -11,7 +13,7 @@ module Middleman
         highlighter_options[:css_class] = [ highlighter_options[:css_class], lexer.tag ].join(' ')
         lexer_options = highlighter_options.delete(:lexer_options)
 
-        formatter = Rouge::Formatters::HTML.new(highlighter_options)
+        formatter = Middleman::Syntax::Formatters::HTML.new(highlighter_options)
         formatter.format(lexer.lex(code, lexer_options))
       end
     end

--- a/middleman-syntax.gemspec
+++ b/middleman-syntax.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files -z -- {fixtures,features}/*`.split("\0")
   s.require_paths = ["lib"]
   s.add_runtime_dependency("middleman-core", [">= 3.2"])
-  s.add_runtime_dependency("rouge", ["~> 1.0"])
+  s.add_runtime_dependency("rouge", ["~> 2.0"])
   s.add_development_dependency("aruba", "~> 0.5.1")
   s.add_development_dependency("cucumber", "~> 1.3.1")
   s.add_development_dependency("fivemat")


### PR DESCRIPTION
This PR upgrades to Rouge 2.0 which was released on June 14th.

See https://github.com/jneen/rouge#formatters for more information.