### PR TITLE
Bump Rouge dependency to latest release (3.1.1 from 2.2.1)

### DIFF
--- a/lib/middleman-syntax/version.rb
+++ b/lib/middleman-syntax/version.rb
@@ -1,5 +1,5 @@
 module Middleman
   module Syntax
-    VERSION = "3.0.0"
+    VERSION = "3.1.0"
   end
 end

--- a/middleman-syntax.gemspec
+++ b/middleman-syntax.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files -z -- {fixtures,features}/*`.split("\0")
   s.require_paths = ["lib"]
   s.add_runtime_dependency("middleman-core", [">= 3.2"])
-  s.add_runtime_dependency("rouge", ["~> 2.0"])
+  s.add_runtime_dependency("rouge", ["~> 3.1"])
   s.add_development_dependency("aruba", "~> 0.5.1")
   s.add_development_dependency("cucumber", "~> 1.3.1")
   s.add_development_dependency("fivemat")


### PR DESCRIPTION
This brings `middleman-syntax` up to date with the latest version of Rouge.

The move from Rouge 2.2.1 to 3.1.1 has [no breaking changes](https://github.com/jneen/rouge/blob/master/CHANGELOG.md) but does bring support for several new languages, themes, and a plethora of bug fixes. 