### PR TITLE
Bump Rouge to 3.2.X

### DIFF
--- a/middleman-syntax.gemspec
+++ b/middleman-syntax.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files -z -- {fixtures,features}/*`.split("\0")
   s.require_paths = ["lib"]
   s.add_runtime_dependency("middleman-core", [">= 3.2"])
-  s.add_runtime_dependency("rouge", ["~> 3.1"])
+  s.add_runtime_dependency("rouge", ["~> 3.2"])
   s.add_development_dependency("aruba", "~> 0.5.1")
   s.add_development_dependency("cucumber", "~> 1.3.1")
   s.add_development_dependency("fivemat")


### PR DESCRIPTION
Since the last Rouge version update 3.2.0 and 3.2.1 have been released. They contain minor lexer updates and new file extension support - test suite here is stable. I wasn't sure if I should increment the version number since v3.1.0 was never pushed to rubygems (#75). Thanks!