### PR TITLE
allow for Linewise Rouge formatter

### DIFF
--- a/lib/middleman-syntax/extension.rb
+++ b/lib/middleman-syntax/extension.rb
@@ -9,6 +9,7 @@ module Middleman
     class SyntaxExtension < Extension
       option :css_class, 'highlight', 'Class name applied to the syntax-highlighted output.'
       option :line_numbers, false, 'Generate line numbers.'
+      option :line_numbers_div, false, 'Generate line numbers with wrapping divs.'
       option :start_line, 1, 'Start the line numbering (if enabled) at the desired integer'
       option :inline_theme, nil, 'A Rouge::CSSTheme that will be used to highlight the output with inline styles instead of using CSS classes.'
       option :wrap, true, 'Wrap the highlighted content in a container (<pre> or <div>, depending on whether :line_numbers is on).'

--- a/lib/middleman-syntax/formatters.rb
+++ b/lib/middleman-syntax/formatters.rb
@@ -12,6 +12,8 @@ module Middleman
                        end
 
           @formatter = Rouge::Formatters::HTMLTable.new(@formatter, opts) if opts[:line_numbers]
+        
+          @formatter = Rouge::Formatters::HTMLLinewise.new(@formatter, class='line-%i') if opts[:line_numbers_div]
 
           if opts.fetch(:wrap, true)
             @formatter = Rouge::Formatters::HTMLPygments.new(@formatter, opts.fetch(:css_class, 'codehilite'))

--- a/lib/middleman-syntax/formatters.rb
+++ b/lib/middleman-syntax/formatters.rb
@@ -13,7 +13,7 @@ module Middleman
 
           @formatter = Rouge::Formatters::HTMLTable.new(@formatter, opts) if opts[:line_numbers]
         
-          @formatter = Rouge::Formatters::HTMLLinewise.new(@formatter, class='line-%i') if opts[:line_numbers_div]
+          @formatter = Rouge::Formatters::HTMLLinewise.new(@formatter, class:'line-%i') if opts[:line_numbers_div]
 
           if opts.fetch(:wrap, true)
             @formatter = Rouge::Formatters::HTMLPygments.new(@formatter, opts.fetch(:css_class, 'codehilite'))

--- a/lib/middleman-syntax/language_parameter_parser.rb
+++ b/lib/middleman-syntax/language_parameter_parser.rb
@@ -9,6 +9,9 @@ module Middleman
           if attribute == "line_numbers" and value == "false"
             return { line_numbers: false }
           end
+          if attribute == "line_numbers_div" and value == "false"
+            return { line_numbers_div: false }
+          end
         end
         {}
       end


### PR DESCRIPTION
Rouge can produce an output with divs around each line. This change allows you to select Linewise Rouge formatter as an option.