### PR TITLE
Remove trailing blank lines from HAML's :code filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Fixed HAML :code filter to remove trailing blank lines
+
 # 3.2.0
 
 - Prep for Middleman v5

--- a/features/haml_filter.feature
+++ b/features/haml_filter.feature
@@ -11,3 +11,15 @@ Feature: Haml :code filter.
     When I go to "/code_haml_filter.html"
     Then I should see '<span class="k">def</span>'
     Then I should see '<pre class="highlight plaintext"><code>This is some code'
+
+  Scenario: Filter doesn't keep trailing blank lines
+    Given a fixture app "test-app"
+    And a file named "config.rb" with:
+      """
+      set :haml, { :ugly => false }
+      activate :syntax
+      """
+    Given the Server is running at "test-app"
+    When I go to "/code_haml_filter.html"
+    Then I should see '<span class="k">def</span>'
+    Then I should see '<pre class="highlight plaintext"><code>This is some code</code></pre>'

--- a/lib/middleman-syntax/haml_monkey_patch.rb
+++ b/lib/middleman-syntax/haml_monkey_patch.rb
@@ -6,6 +6,7 @@ if defined? Haml
         include Base
 
         def render(code)
+          code = code.rstrip
           code = code.encode(Encoding::UTF_8)
 
           # Allow language to be specified via a special comment like:


### PR DESCRIPTION
Without this change, every blank lines until other content in the haml file will be sent to the `:code` filter, which leads to empty lines in the code block:

```
Hello world
555

:code
  # lang: ruby
  def hello
    puts 'hi'
  end



BYe
```

![image](https://user-images.githubusercontent.com/894561/100526449-0e9e2500-3197-11eb-963d-f20a1981b173.png)

This is even done in the `:javascript` filter, which wouldn't care about those: https://github.com/haml/haml/blob/000b6657b5a9fbc18e64ba75edfd2a2a2c8e8bc2/lib/haml/filters.rb#L220