### PR TITLE
Remove unnecessary Nokogiri gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,3 @@ gem 'haml', RUBY_VERSION > '3.0' ? '< 7' : '< 6'
 gem 'slim', '>= 3', '< 5'
 gem 'kramdown'
 gem "redcarpet"
-
-# For old Rubies
-gem 'nokogiri', '~> 1.12.0'


### PR DESCRIPTION
It seems it was introduced some years ago to fix something in Travis (https://github.com/middleman/middleman-syntax/commit/270a86dd56220e069d55461ec570c73434de4a41), but I'm almost sure we can delete it ... let's see what current CI says.

So we can also get rid of all those security warnings:

<img width="944" alt="Captura de pantalla 2024-01-29 a las 21 04 45" src="https://github.com/middleman/middleman-syntax/assets/576701/41efeac9-cdcb-49c1-9dbe-b4ae855a5bb1">

