### PR TITLE
fix: support Ruby 4 by allowing Rouge 4.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["3.4", "3.3", "3.2", "3.1", "3.0", "2.7"]
+        ruby-version: ["4.0", "3.4", "3.3", "3.2", "3.1", "3.0", "2.7"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'cucumber'
 gem 'capybara'
 
 # Optional dependencies, included for tests
-gem 'haml', RUBY_VERSION > '3.0' ? '< 7' : '< 6'
+gem 'haml'
 gem 'slim'
 gem 'kramdown'
 gem 'redcarpet'

--- a/middleman-syntax.gemspec
+++ b/middleman-syntax.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -z`.split("\0")
   s.test_files = `git ls-files -z -- {fixtures,features}/*`.split("\0")
   s.add_runtime_dependency("middleman-core", [">= 3.2"])
-  s.add_runtime_dependency("rouge", ["~> 3.2"])
+  s.add_runtime_dependency("rouge", [">= 3.2", "< 5"])
 end


### PR DESCRIPTION
Ruby 4.x [dropped `CGI` almost entirely](https://stdgems.org/cgi/), which Rouge 3.x depends on, thus supporting Ruby 4.x requires allowing Rouge 4.x, which has been out for 3 years; supports Ruby 2.7+ and appears very stable.

The breaking changes in Rouge 4.x don't affect modern middleman since they mainly are just dropping Ruby < 2.7:

https://github.com/rouge-ruby/rouge/blob/master/CHANGELOG.md#version-400-2022-09-04

Also dropped the dev-only Gemfile haml restriction, as the monkey patch seems to work fine with haml 7; and haml 6 and tests seems to work perfectly fine on Ruby 2.7. Since we dropped Ruby < 2.7 some time ago, perhaps this restriction was intended for even older Rubies.